### PR TITLE
Implement results cache for #17

### DIFF
--- a/differ/Collision.hx
+++ b/differ/Collision.hx
@@ -17,15 +17,22 @@ class Collision {
     } //test
 
         /** Test a single shape against multiple other shapes.
-            When no collision is found, this function returns an empty array, this function will never return null.
-            Returns a list of `ShapeCollision` information for each collision found. */
-    public static function shapeWithShapes( shape1:Shape, shapes:Array<Shape> ) : Array<ShapeCollision> {
+            When no collision is found, this function returns empty results, this function will never return null.
+            Returns a list of `ShapeCollision` information for each collision found.
+            `for(result in results) {  result... }` */
+    public static function shapeWithShapes( shape1:Shape, shapes:Array<Shape>, ?into:Results<ShapeCollision> ) : Results<ShapeCollision> {
 
-        var results = [];
+        var results: Results<ShapeCollision> =
+            if(into != null) {
+                into.clear();
+            } else {
+                new Results<ShapeCollision>(shapes.length);
+            }
 
         for(other_shape in shapes) {
 
-            var result = shapeWithShape(shape1, other_shape, null);
+            var value = results.pull();
+            var result = shapeWithShape(shape1, other_shape, value);
             if(result != null) {
                 results.push(result);
             }
@@ -47,13 +54,20 @@ class Collision {
 
         /** Test a ray between two points against a list of shapes.
             When no collision is found, this function returns an empty array, this function will never return null.
-            Returns a list of `RayCollision` information for each collision found. */
-    public static function rayWithShapes( ray:Ray, shapes:Array<Shape> ) : Array<RayCollision> {
+            Returns a list of `RayCollision` information for each collision found.
+            `for(result in results) {  result... }`  */
+    public static function rayWithShapes( ray:Ray, shapes:Array<Shape>, ?into:Results<RayCollision> ) : Results<RayCollision> {
 
-        var results = [];
+        var results: Results<RayCollision> =
+            if(into != null) {
+                into.clear();
+            } else {
+                new Results<RayCollision>(shapes.length);
+            }
 
         for(shape in shapes) {
-            var result = rayWithShape(ray, shape, null);
+            var value = results.pull();
+            var result = rayWithShape(ray, shape, value);
             if(result != null) {
                 results.push(result);
             }
@@ -74,13 +88,20 @@ class Collision {
 
         /** Test a ray against a list of other rays.
             When no collision is found, this function returns an empty array, this function will never return null.
-            Returns a list of `RayIntersection` information for each collision found. */
-    public static function rayWithRays( ray:Ray, rays:Array<Ray> ) : Array<RayIntersection> {
+            Returns a list of `RayIntersection` information for each collision found.
+            `for(result in results) {  result... }`  */
+    public static function rayWithRays( ray:Ray, rays:Array<Ray>, ?into:Results<RayIntersection> ) : Results<RayIntersection> {
 
-        var results = [];
+        var results: Results<RayIntersection> =
+            if(into != null) {
+                into.clear();
+            } else {
+                new Results<RayIntersection>(rays.length);
+            }
 
         for(other in rays) {
-            var result = rayWithRay(ray, other, null);
+            var value = results.pull();
+            var result = rayWithRay(ray, other, value);
             if(result != null) {
                 results.push(result);
             }
@@ -126,3 +147,106 @@ class Collision {
 
 
 } //Collision
+
+
+//Internal helpers
+
+private typedef Constructible = {
+    public function new():Void;
+}
+
+/** 
+    A result set container.
+    Items in the container are preallocated, then pulled out and updated.
+    The container will behave like a regular container, where iterating, 
+    and get will only return values from the valid set. Pushing items
+    will increase the valid set.
+*/
+@:generic
+class Results<T:Constructible> {
+
+    public var length (get, never) : Int;
+    public var total (get, never) : Int;
+
+        //internal
+    var items:Array<T>;
+    var count:Int = 0;
+
+        /** Create a new set of results. 
+            Preallocates `size` items into the list. */
+    public function new(size:Int) {
+        items = [for (i in 0...size) new T()];
+    }
+
+        /** Add an item to the container. */
+    inline public function push(value:T) : Void {
+
+        items[count] = value;
+        
+        count++;
+
+    } //push
+
+        /** Get the item at the given index. 
+            If the index is < 0 and > length-1 it returns null; */
+    inline public function get(index:Int) : T {
+
+        if(index < 0 && index > length-1) return null;
+
+        return items[index];
+
+    } //get
+
+        /** Grabs the last item from the cache to reuse.
+            If there are no free items, it adds a new one.
+            Typically internal use. */
+    inline public function pull() : T {
+
+            //no more?
+        if(items.length == count) items.push(new T());
+            //return the last item
+        return items[count];
+
+    } //pull
+
+        /** Clear the container, which sets the length to 0. 
+            This keeps the cached items but won't return them 
+            while iterating or accessing them.
+            Returns `this` for convience. */
+    inline public function clear() : Results<T> {
+        count = 0;
+        return this;
+    }
+
+        /** Returns an iterator over the valid items in this set. */
+    inline public function iterator() : ResultsIterator<T> {
+        return new ResultsIterator<T>(this);
+    }
+
+
+        // getters
+    inline function get_length() : Int return count;
+    inline function get_total() : Int return items.length;
+
+} //Results
+
+@:generic
+class ResultsIterator<T:Constructible> {
+
+    var index: Int = 0;
+    var results: Results<T>;
+
+    public function new(_results:Results<T>) {
+        index = 0;
+        results = _results;
+    }
+
+    public inline function hasNext() {
+        return index < results.length;
+    }
+
+    public inline function next() {
+        return results.get(index++);
+    }
+
+} //ResultsIterator

--- a/differ/data/ShapeCollision.hx
+++ b/differ/data/ShapeCollision.hx
@@ -8,6 +8,8 @@ import differ.data.*;
 @:publicFields
 class ShapeCollision {
 
+   //
+
         /** The overlap amount */
     var overlap : Float = 0.0;
         /** X component of the separation vector, when subtracted from shape 1 will separate it from shape 2 */

--- a/tests/usage0/src/states/Rays.hx
+++ b/tests/usage0/src/states/Rays.hx
@@ -11,9 +11,11 @@ import differ.data.*;
 
 class Rays extends luxe.States.State {
 
-    var beam : Ray;
-    var others : Array<Ray>;
-    var colors:Array<Color>;
+    var beam: Ray;
+    var others: Array<Ray>;
+    var colors: Array<Color>;
+    var results: Results<RayIntersection>;
+
     var flip = false;
 
     override function onenter<T>(_:T) {
@@ -38,6 +40,9 @@ class Rays extends luxe.States.State {
         }
 
         Main.rays.push(beam);
+
+            //allocate a precreated list of results, to avoid allocating every time
+        results = new Results<RayIntersection>(colors.length);
 
     }
 
@@ -84,7 +89,7 @@ class Rays extends luxe.States.State {
 
     override function update(dt:Float) {
 
-        var colls = Collision.rayWithRays(beam, others);
+        var colls = Collision.rayWithRays(beam, others, results);
 
         Luxe.draw.text({
             point_size:15,


### PR DESCRIPTION
This adds a way to avoid allocations for the plural api endpoints by adding a custom container.