### PR TITLE
Compilation fix for Haxe 4.0.0.5preview

### DIFF
--- a/differ/shapes/Circle.hx
+++ b/differ/shapes/Circle.hx
@@ -9,9 +9,9 @@ import differ.sat.*;
 class Circle extends Shape {
 
         /** The radius of this circle. Set on construction */
-    public var radius( get_radius, never ) : Float;
+    public var radius( get, never ) : Float;
         /** The transformed radius of this circle, based on the scale/rotation */
-    public var transformedRadius( get_transformedRadius, never ) : Float;
+    public var transformedRadius( get, never ) : Float;
 
     var _radius:Float;
 


### PR DESCRIPTION
Haxe 4.0.0.5preview doesn't work with custom getters/setters now, so i had to make small update to `Circle` class to make it work there